### PR TITLE
fix path to header files to install.

### DIFF
--- a/wscript
+++ b/wscript
@@ -95,7 +95,7 @@ lib_source = ['src/sratom.c']
 def build(bld):
     # C Headers
     includedir = '${INCLUDEDIR}/sratom-%s/sratom' % SRATOM_MAJOR_VERSION
-    bld.install_files(includedir, bld.path.ant_glob('sratom/*.h'))
+    bld.install_files(includedir, bld.path.ant_glob('include/sratom/*.h'))
 
     # Pkgconfig file
     autowaf.build_pc(bld, 'SRATOM', SRATOM_VERSION, SRATOM_MAJOR_VERSION, [],


### PR DESCRIPTION
The header path has changed from `sratom/*.h` to `include/sratom/*.h`, so installation path should follow that.